### PR TITLE
Add dub build

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -8,11 +8,42 @@
 
     "excludedSourceFiles":
     [
-        "source/main.d",
-        "source/cli.d",
-        "source/bench.d",
-        "source/tester.d",
-        "source/be/asmtest/*.d",
-        "source/tests/*.d"
+        "source/be/asmtest/*.d"
+    ],
+
+    "configurations":
+    [
+        {
+            "name": "library",
+            "targetType": "library",
+            "excludedSourceFiles":
+            [
+                "source/main.d",
+                "source/cli.d",
+                "source/bench.d",
+                "source/tester.d",
+                "source/tests/*.d"
+            ],
+        },
+        {
+            "name": "cli",
+            "targetType": "executable",
+            "versions": [ "cli" ]
+        },
+        {
+            "name": "bench",
+            "targetType": "executable",
+            "versions": [ "bench" ]
+        },
+        {
+            "name": "devtest",
+            "targetType": "executable",
+            "versions": [ "devtest" ]
+        },
+        {
+            "name": "test",
+            "targetType": "executable",
+            "versions": [ "test" ]
+        }
     ]
 }

--- a/dub.json
+++ b/dub.json
@@ -1,0 +1,18 @@
+{
+    "name": "vox",
+
+    "sourcePaths":
+    [
+        "source"
+    ],
+
+    "excludedSourceFiles":
+    [
+        "source/main.d",
+        "source/cli.d",
+        "source/bench.d",
+        "source/tester.d",
+        "source/be/asmtest/*.d",
+        "source/tests/*.d"
+    ]
+}

--- a/source/fe/ast_to_ir.d
+++ b/source/fe/ast_to_ir.d
@@ -577,11 +577,11 @@ IrIndex buildGEPEx(ref IrGenState gen, TokenIndex loc, IrIndex currentBlock, Exp
 	}
 	switch (aggrPtrExpr.kind) with(ExprValueKind)
 	{
-		case value: assert(false); break;
+		case value: assert(false);
 		case ptr_to_data: break;
 		case ptr_to_ptr_to_data:
 			aggrPtr = ExprValue(aggrPtr).load(gen, loc, currentBlock);
-			assert(false); break;
+			assert(false);
 		case struct_sub_index:
 			IrIndex aggrType = gen.ir.getValueType(c, aggrPtr);
 			switch (aggrType.typeKind) {


### PR DESCRIPTION
Don't know if you want that!

This adds a DUB file so that vox can be built with `dub` instead of -i.
Because the tests and main.d are inside the source dir it list every files independently.
I can build voxelman2 with vox as dependency.